### PR TITLE
bug fix - project install failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ setup: ## configure the containers and install dependencies
 		$(EXEC) chown app:www-data /app/files
 		$(EXEC) chmod g+wr /app/files
 # Install project dependencies
+		$(EXEC_U) "$(COMPOSER) update symfony/flex --no-plugins --no-scripts"
 		$(EXEC_U) "$(COMPOSER) install"
 		$(EXEC_U) "$(YARN) install"
 		$(EXEC_U) "$(YARN) encore dev"

--- a/etc/dev/php/Dockerfile
+++ b/etc/dev/php/Dockerfile
@@ -1,11 +1,11 @@
-FROM php:8-fpm-alpine AS base
+FROM php:8.0-fpm-alpine AS base
 WORKDIR /app
 
 
 FROM base AS dev
 
 # Install and enable xdebug.
-RUN apk add --no-cache $PHPIZE_DEPS \
+RUN apk add --no-cache $PHPIZE_DEPS --update linux-headers \
     && pecl install xdebug \
     && docker-php-ext-enable xdebug
 COPY xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini


### PR DESCRIPTION
Made some modifications in the project dependencies, in order to enable the installation of the project
* lock php version to `8.0.*` (`php:8.0-fpm-alpine`)
* update linux headers when installing xdebug
* update `symfony/flex` before installing project dependencies